### PR TITLE
Werkzeug is missing in requirements.txt

### DIFF
--- a/Chapter02/ThoughtsBackend/requirements.txt
+++ b/Chapter02/ThoughtsBackend/requirements.txt
@@ -9,3 +9,4 @@ faker==1.0.7
 pyjwt==1.7.1
 cryptography==2.6.1
 parse==1.12.0
+Werkzeug==0.16.1


### PR DESCRIPTION
Your must install Werkzeug==0.16.1. Without installation Werkzeug==0.16.1 the error will appear. More details: https://github.com/noirbizarre/flask-restplus/issues/777